### PR TITLE
Fix TypeScript references

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,2 @@
 /// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />


### PR DESCRIPTION
## Summary
- add missing reference to `astro/client` in `env.d.ts`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687420e5ad948323a663259a104da62c